### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ services:
     ports:
       - "15432:5432"
     environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_DB:       api-gw
       POSTGRES_USER:     kong
       POSTGRES_PASSWORD: 


### PR DESCRIPTION
I was getting this error when running  $docker-compose up kong-db


Starting microservices-security-fundumentals_kong-db_1 ... done
Attaching to microservices-security-fundumentals_kong-db_1
kong-db_1                 | Error: Database is uninitialized and superuser password is not specified.
kong-db_1                 |        You must specify POSTGRES_PASSWORD to a non-empty value for the
kong-db_1                 |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
kong-db_1                 | 
kong-db_1                 |        You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
kong-db_1                 |        connections without a password. This is *not* recommended.
kong-db_1                 | 
kong-db_1                 |        See PostgreSQL documentation about "trust":
kong-db_1                 |        https://www.postgresql.org/docs/current/auth-trust.html